### PR TITLE
fix: Use of CachedEnforcer throws error from clang

### DIFF
--- a/casbin/enforcer_cached.h
+++ b/casbin/enforcer_cached.h
@@ -84,6 +84,8 @@ public:
          */
     CachedEnforcer(const std::string& model_path, const std::string& policy_file, bool enable_log);
 
+    virtual ~CachedEnforcer() = default;
+
     bool Enforce(Scope scope);
 
     // Enforce with a vector param,decides whether a "subject" can access a

--- a/include/casbin/casbin_types.h
+++ b/include/casbin/casbin_types.h
@@ -19,6 +19,7 @@
 #ifndef CASBIN_CPP_CASBIN_TYPES_H
 #define CASBIN_CPP_CASBIN_TYPES_H
 
+#include <string>
 #include <variant>
 #include <vector>
 #include <initializer_list>


### PR DESCRIPTION
add string to casbin_types for visibility of std::hash<string> when using enforcer_cached
