### PR TITLE
feat: inheritance of exceptions public

### DIFF
--- a/casbin/exception/casbin_adapter_exception.h
+++ b/casbin/exception/casbin_adapter_exception.h
@@ -20,7 +20,7 @@
 namespace casbin {
 
 // Exception class for Casbin Adapter Exception.
-class CasbinAdapterException : std::logic_error {
+class CasbinAdapterException : public std::logic_error {
 public:
     using std::logic_error::logic_error;
 };

--- a/casbin/exception/casbin_enforcer_exception.h
+++ b/casbin/exception/casbin_enforcer_exception.h
@@ -20,7 +20,7 @@
 namespace casbin {
 
 // Exception class for Casbin Enforcer Exception.
-class CasbinEnforcerException : std::runtime_error {
+class CasbinEnforcerException : public std::runtime_error {
 public:
     using std::runtime_error::runtime_error;
 };

--- a/casbin/exception/casbin_rbac_exception.h
+++ b/casbin/exception/casbin_rbac_exception.h
@@ -20,7 +20,7 @@
 namespace casbin {
 
 // Exception class for Casbin Adapter Exception.
-class CasbinRBACException : std::invalid_argument {
+class CasbinRBACException : public std::invalid_argument {
 public:
     using std::invalid_argument::invalid_argument;
 };

--- a/casbin/exception/illegal_argument_exception.h
+++ b/casbin/exception/illegal_argument_exception.h
@@ -20,7 +20,7 @@
 namespace casbin {
 
 // Exception class for illegal arguments.
-class IllegalArgumentException : std::invalid_argument {
+class IllegalArgumentException : public std::invalid_argument {
 public:
     using std::invalid_argument::invalid_argument;
 };

--- a/casbin/exception/io_exception.h
+++ b/casbin/exception/io_exception.h
@@ -20,7 +20,7 @@
 namespace casbin {
 
 // Exception class for I/O operations.
-class IOException : std::runtime_error {
+class IOException : public std::runtime_error {
 public:
     using std::runtime_error::runtime_error;
 };

--- a/casbin/exception/missing_required_sections.h
+++ b/casbin/exception/missing_required_sections.h
@@ -20,7 +20,7 @@
 namespace casbin {
 
 // Exception class for missing required sections.
-class MissingRequiredSections : std::domain_error {
+class MissingRequiredSections : public std::domain_error {
 public:
     using std::domain_error::domain_error;
 };

--- a/casbin/exception/unsupported_operation_exception.h
+++ b/casbin/exception/unsupported_operation_exception.h
@@ -20,7 +20,7 @@
 namespace casbin {
 
 // Exception class for unsupported operations.
-class UnsupportedOperationException : std::logic_error {
+class UnsupportedOperationException : public std::logic_error {
 public:
     using std::logic_error::logic_error;
 };


### PR DESCRIPTION
Make inheritance of std exception types public for catching of inherited exception types and for access to the what() method.

Signed-off-by: William Michaels <bill@polarity.io>


